### PR TITLE
Xygeni-Bumper - org.yaml:snakeyaml from 1.30 to 2.0

### DIFF
--- a/user-profile-app/pom.xml
+++ b/user-profile-app/pom.xml
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.30</version>
+                <version>2.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
## Bumps org.yaml:snakeyaml:1.30 to 2.0 
### 🔍 Vulnerability Details 

- **Component:** org.yaml:snakeyaml 
- **Fixed Version:** 2.0 
### 📝 Description 

CVE-2022-1471 SnakeYaml's Constructor() class does not restrict types which can be instantiated during deserialization. Deserializing yaml content provided by an attacker can lead to remote code execution. We recommend using SnakeYaml's SafeConsturctor when parsing untrusted content to restrict deserialization. We recommend upgrading to version 2.0 and beyond. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2022-1471 



