### PR TITLE
Xygeni-Bumper - org.springframework:spring-web from 5.3.31 to 6.0.0

### DIFF
--- a/user-profile-app/pom.xml
+++ b/user-profile-app/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
-                <version>5.3.31</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
## Bumps org.springframework:spring-web:5.3.31 to 6.0.0 
### 🔍 Vulnerability Details 

- **Component:** org.springframework:spring-web 
- **Fixed Version:** 6.0.0 
### 📝 Description 

GHSA-4wrc-f8pq-fpqp Pivotal Spring Framework contains unsafe Java deserialization methods - Pivotal Spring Framework before 6.0.0 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required.

Maintainers recommend investigating alternative components or a potential mitigating control. Version 4.2.6 and 3.2.17 contain [enhanced documentation](https://github.com/spring-projects/spring-framework/commit/5cbe90b2cd91b866a5a9586e460f311860e11cfa) advising users to take precautions against unsafe Java deserialization, version 5.3.0 [deprecate the impacted classes](https://github.com/spring-projects/spring-framework/issues/25379) and version 6.0.0 [removed it entirely](https://github.com/spring-projects/spring-framework/issues/27422). 
### 🔗 References 

For more information, please refer to https://github.com/advisories/GHSA-4wrc-f8pq-fpqp 



