### PR TITLE
Xygeni-Bumper - update 4 dependency versions

### DIFF
--- a/user-profile-app/pom.xml
+++ b/user-profile-app/pom.xml
@@ -33,7 +33,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.30</version>
+                <version>2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/user-profile-app/pom.xml
+++ b/user-profile-app/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
-                <version>5.3.31</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>

--- a/user-profile-app/pom.xml
+++ b/user-profile-app/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>
-                <version>9.0.83</version>
+                <version>9.0.98</version>
             </dependency>
             <dependency>
                 <groupId>org.xmlunit</groupId>

--- a/user-profile-app/pom.xml
+++ b/user-profile-app/pom.xml
@@ -63,7 +63,7 @@
             <dependency>
                 <groupId>org.xmlunit</groupId>
                 <artifactId>xmlunit-core</artifactId>
-                <version>2.9.1</version>
+                <version>2.10.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
## Bumps org.springframework:spring-web:5.3.31 to 6.0.0 
### 🔍 Vulnerability Details 

- **Component:** org.springframework:spring-web 
- **Fixed Version:** 6.0.0 
### 📝 Description 

GHSA-4wrc-f8pq-fpqp Pivotal Spring Framework contains unsafe Java deserialization methods - Pivotal Spring Framework before 6.0.0 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required.

Maintainers recommend investigating alternative components or a potential mitigating control. Version 4.2.6 and 3.2.17 contain [enhanced documentation](https://github.com/spring-projects/spring-framework/commit/5cbe90b2cd91b866a5a9586e460f311860e11cfa) advising users to take precautions against unsafe Java deserialization, version 5.3.0 [deprecate the impacted classes](https://github.com/spring-projects/spring-framework/issues/25379) and version 6.0.0 [removed it entirely](https://github.com/spring-projects/spring-framework/issues/27422). 
### 🔗 References 

For more information, please refer to https://github.com/advisories/GHSA-4wrc-f8pq-fpqp 



## Bumps org.yaml:snakeyaml:1.30 to 2.0 
### 🔍 Vulnerability Details 

- **Component:** org.yaml:snakeyaml 
- **Fixed Version:** 2.0 
### 📝 Description 

CVE-2022-1471 SnakeYaml's Constructor() class does not restrict types which can be instantiated during deserialization. Deserializing yaml content provided by an attacker can lead to remote code execution. We recommend using SnakeYaml's SafeConsturctor when parsing untrusted content to restrict deserialization. We recommend upgrading to version 2.0 and beyond. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2022-1471 



## Bumps org.apache.tomcat.embed:tomcat-embed-core:9.0.83 to 9.0.98 
### 🔍 Vulnerability Details 

- **Component:** org.apache.tomcat.embed:tomcat-embed-core 
- **Fixed Version:** 9.0.98 
### 📝 Description 

GHSA-27hp-xhwr-wr2m Apache Tomcat Time-of-check Time-of-use (TOCTOU) Race Condition vulnerability - Time-of-check Time-of-use (TOCTOU) Race Condition vulnerability in Apache Tomcat.

This issue affects Apache Tomcat: from 11.0.0-M1 through 11.0.1, from 10.1.0-M1 through 10.1.33, from 9.0.0.M1 through 9.0.97.

The mitigation for CVE-2024-50379 was incomplete.

Users running Tomcat on a case insensitive file system with the default servlet write enabled (readonly initialisation 
parameter set to the non-default value of false) may need additional configuration to fully mitigate CVE-2024-50379 depending on which version of Java they are using with Tomcat:
- running on Java 8 or Java 11: the system property sun.io.useCanonCaches must be explicitly set to false (it defaults to true)
- running on Java 17: the system property sun.io.useCanonCaches, if set, must be set to false (it defaults to false)
- running on Java 21 onwards: no further configuration is required (the system property and the problematic cache have been removed)

Tomcat 11.0.3, 10.1.35 and 9.0.99 onwards will include checks that sun.io.useCanonCaches is set appropriately before allowing the default servlet to be write enabled on a case insensitive file system. Tomcat will also set sun.io.useCanonCaches to false by default where it can. 
### 🔗 References 

For more information, please refer to https://github.com/advisories/GHSA-27hp-xhwr-wr2m 



## Bumps org.xmlunit:xmlunit-core:2.9.1 to 2.10.0 
### 🔍 Vulnerability Details 

- **Component:** org.xmlunit:xmlunit-core 
- **Fixed Version:** 2.10.0 
### 📝 Description 

GHSA-chfm-68vv-pvw5 XMLUnit for Java has Insecure Defaults when Processing XSLT Stylesheets - ### Impact
When performing XSLT transformations XMLUnit for Java did not disable XSLT extension functions by default. Depending on the XSLT processor being used this could allow arbitrary code to be executed when XMLUnit is used to transform data with a stylesheet who's source can not be trusted. If the stylesheet can be provided externally this may even lead to a remote code execution.

## Patches
Users are advised to upgrade to XMLUnit for Java 2.10.0 where the default has been changed by means of https://github.com/xmlunit/xmlunit/commit/b81d48b71dfd2868bdfc30a3e17ff973f32bc15b

### Workarounds
XMLUnit's main use-case is performing tests on code that generates or processes XML. Most users will not use it to perform arbitrary XSLT transformations.

Users running XSLT transformations with untrusted stylesheets should explicitly use XMLUnit's APIs to pass in a pre-configured TraX `TransformerFactory` with extension functions disabled via features and attributes. The required `setFactory` or `setTransformerFactory` methods have been available since XMLUnit for Java 2.0.0.

### References
[Bug Report](https://github.com/xmlunit/xmlunit/issues/264)
[JAXP Security Guide](https://docs.oracle.com/en/java/javase/22/security/java-api-xml-processing-jaxp-security-guide.html#GUID-E345AA09-801E-4B95-B83D-7F0C452538AA)
 
### 🔗 References 

For more information, please refer to https://github.com/advisories/GHSA-chfm-68vv-pvw5 



