### PR TITLE
Xygeni SAST java.unrestricted_request_mapping ...troller/UserController.java 67

### DIFF
--- a/user-profile-app/src/main/java/com/example/controller/UserController.java
+++ b/user-profile-app/src/main/java/com/example/controller/UserController.java
@@ -60,7 +60,7 @@ public class UserController {
         return "redirect:/users";
     }
 
-    @GetMapping("/delete/{id}")
+    @DeleteMapping("/{id}")
     public String deleteUser(@PathVariable Long id) {
         userService.deleteUser(id);
         return "redirect:/users";


### PR DESCRIPTION
<h2>Fixed Fixed java.unrestricted_request_mapping in user-profile-app/src/main/java/com/example/controller/UserController.java at line 67</h2><br/>The vulnerability in the original code was due to the use of a `GET` request for the delete operation at line 67. This can lead to security issues such as CSRF (Cross-Site Request Forgery) attacks. The fix involves changing the `@GetMapping` annotation to `@DeleteMapping` for the `deleteUser` method. This ensures that the delete operation is performed using an HTTP DELETE request, which is more appropriate for operations that modify server state and is less susceptible to CSRF attacks.<br/>