### PR TITLE
Xygeni SAST java.sql_injection issues ...src/main/VulnerableApp.java 15

### DIFF
--- a/user-profile-app/src/main/VulnerableApp.java
+++ b/user-profile-app/src/main/VulnerableApp.java
@@ -8,11 +8,11 @@ public class VulnerableApp {
         String email = args[0];
 
         try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
-             Statement stmt = conn.createStatement()) {
+             PreparedStatement pstmt = conn.prepareStatement("SELECT * FROM users WHERE email = ?")) {
 
-            // Vulnerable SQL statement
-            String query = "SELECT * FROM users WHERE email = '" + email + "'";
-            ResultSet rs = stmt.executeQuery(query);
+            // Secure SQL statement using PreparedStatement
+            pstmt.setString(1, email);
+            ResultSet rs = pstmt.executeQuery();
 
             while (rs.next()) {
                 System.out.println("User: " + rs.getString("name") + " - " + rs.getString("email"));


### PR DESCRIPTION
<h2>Fixed java.sql_injection issues in user-profile-app/src/main/VulnerableApp.java at line 15</h2><br/>

* java.sql_injection : Line 15
  * Fix: Changed the `Statement` to `PreparedStatement` and used a parameterized query to prevent SQL injection. The `setString` method is used to safely insert the user input into the query.
  * Guide: Always use `PreparedStatement` for executing SQL queries with user input. This prevents SQL injection by safely handling user input as parameters rather than directly concatenating them into the SQL query string.<br/>
