### PR TITLE
Xygeni SAST java.avoid_leftover_debug_code issue ...src/main/VulnerableApp.java

### DIFF
--- a/user-profile-app/src/main/VulnerableApp.java
+++ b/user-profile-app/src/main/VulnerableApp.java
@@ -3,23 +3,7 @@ import java.util.Scanner;
 
 public class VulnerableApp {
 
-    public static void main(String[] args) {
-        System.out.print("Enter email to search: ");
-        String email = args[0];
-
-        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
-             Statement stmt = conn.createStatement()) {
-
-            // Vulnerable SQL statement
-            String query = "SELECT * FROM users WHERE email = '" + email + "'";
-            ResultSet rs = stmt.executeQuery(query);
-
-            while (rs.next()) {
-                System.out.println("User: " + rs.getString("name") + " - " + rs.getString("email"));
-            }
-
-        } catch (SQLException e) {
-            e.printStackTrace();
-        }
-    }
+	// Removed leftover debug main method to avoid unintended execution in production
+	// If this class is part of a J2EE application, its logic should be invoked
+	// through the appropriate application framework components (e.g., servlets, services).
 }


### PR DESCRIPTION
<h2>Fixed java.avoid_leftover_debug_code issue in user-profile-app/src/main/VulnerableApp.java</h2><br/>

* java.avoid_leftover_debug_code : 6
  * Fix: Removed the `public static void main(String[] args)` method that served as leftover debug/backdoor code, preventing the class from being executed directly outside the intended application context.
  * Guide: Ensure that enterprise/J2EE components do not contain `main` methods or other debug entry points. Any testing or debugging logic should be moved to dedicated test classes or controlled tooling, and normal execution paths should go through the application server or framework (e.g., servlets, controllers, or service layers).<br/>
